### PR TITLE
Add StarOffice style

### DIFF
--- a/codehighlighter/python/pythonpath/pygments/styles/staroffice.py
+++ b/codehighlighter/python/pythonpath/pygments/styles/staroffice.py
@@ -1,0 +1,15 @@
+from pygments.style import Style
+from pygments.token import Keyword, Name, Comment, String, Error, \
+     Number, Operator, Generic
+
+class StarOfficeStyle(Style):
+    default_style = ""
+    styles = {
+        Comment:                '#808080',   # Gray
+        Keyword:                '#0000FF',   # Blue
+        Name:                   '#008000',   # Green
+        Name.Function:          '#008000',   # Green
+        Name.Class:             '#008000',   # Green
+        Number:                 '#FF0000',   # Red
+        String:                 '#FF0000'    # Red
+    }

--- a/codehighlighter/python/pythonpath/pygments/styles/staroffice.py
+++ b/codehighlighter/python/pythonpath/pygments/styles/staroffice.py
@@ -6,10 +6,10 @@ class StarofficeStyle(Style):
     default_style = ""
     styles = {
         Comment:                '#808080',   # Gray
-        Keyword:                '#0000FF',   # Blue
+        Error:                  '#800000',   # Red
+        Keyword:                '#000080',   # Blue
         Name:                   '#008000',   # Green
-        Name.Function:          '#008000',   # Green
-        Name.Class:             '#008000',   # Green
-        Number:                 '#FF0000',   # Red
-        String:                 '#FF0000'    # Red
+        Number:                 '#FF0000',   # Lightred
+        Operator:               '#000080',   # Blue
+        String:                 '#FF0000',   # Lightred
     }

--- a/codehighlighter/python/pythonpath/pygments/styles/staroffice.py
+++ b/codehighlighter/python/pythonpath/pygments/styles/staroffice.py
@@ -2,7 +2,7 @@ from pygments.style import Style
 from pygments.token import Keyword, Name, Comment, String, Error, \
      Number, Operator, Generic
 
-class StarOfficeStyle(Style):
+class StarofficeStyle(Style):
     default_style = ""
     styles = {
         Comment:                '#808080',   # Gray


### PR DESCRIPTION
Similar to StarOffice IDE, also used in OpenOffice and LibreOffice. 

Note that brackets, a subset of Punctuation, are not blue.